### PR TITLE
bump version in README to 0.1.1-SNAPSHOT

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ to `mathias` and `ckampfe` for doing the hard work :)
 
 ## Usage
 
-To use this in your project, add `[sooheon/boot-gorilla "0.1.0-SNAPSHOT"]` to your `:dependencies`
+To use this in your project, add `[sooheon/boot-gorilla "0.1.1-SNAPSHOT"]` to your `:dependencies`
 and then require the task: `(require '[sooheon.boot-gorilla :refer [gorilla]])`
 
 Run the task from your project directly like: `boot gorilla -b`


### PR DESCRIPTION
Tried to pull `0.1.0-SNAPSHOT` and realized it was `0.1.1-SNAPSHOT` on clojars.

Also wanted to say thank you for keeping this up to date :)

I mentioned your fork as the most up-to-date version here: https://github.com/JonyEpsilon/gorilla-repl/issues/259